### PR TITLE
Update main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,26 @@ permissions:
 env:
   PLUGIN_JSON: "0.0.1"
   TAG_EXISTS: false
+  PLUGIN_NAME: "my_plugin"
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      plugin_name: ${{ steps.init.outputs.plugin_name }}
+    steps:        
+    - name: Get plugin name
+      id: init
+      run: |
+        echo "plugin_name=${{ env.PLUGIN_NAME }}" >> $GITHUB_OUTPUT
+
   release:
+    needs: check
+    if: startsWith(needs.check.outputs.plugin_name, 'MY_PLUGIN') == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Get plugin version
         run: |
           echo 'PLUGIN_JSON<<EOF' >> $GITHUB_ENV
@@ -40,7 +54,7 @@ jobs:
         uses: TheDoctor0/zip-release@0.7.1
         with:
           type: 'zip'
-          filename: 'my_plugin.zip'
+          filename: '${{env.PLUGIN_NAME}}.zip'
           exclusions: '*.git* setup.py'
           directory: '.'
           path: '.'
@@ -48,7 +62,7 @@ jobs:
         uses: ncipollo/release-action@v1.12.0
         with:
           tag: "${{fromJson(env.PLUGIN_JSON).version}}"
-          artifacts: 'my_plugin.zip'
+          artifacts: '${{env.PLUGIN_NAME}}.zip'
           allowUpdates: true
           replacesArtifacts: true
           body: |


### PR DESCRIPTION
It's a workaround, because the github workflow can't access env variables in a job-level conditional expression, so I had to create another job.
I used `MY_PLUGIN` in the startsWith function so that it would not be replaced by the setup script. Thanks to the fact that startsWith is case insensitive, it should work.

Fixes #2.