### PR TITLE
Fix "NameError: name 'date' is not defined"

### DIFF
--- a/my_plugin.py
+++ b/my_plugin.py
@@ -1,6 +1,6 @@
 from cat.mad_hatter.decorators import tool, hook
 from pydantic import BaseModel
-from datetime import datetime
+from datetime import datetime, date
 
 class MySettings(BaseModel):
     required_int: int


### PR DESCRIPTION
When I upload the default source code I get the error: `NameError: name 'date' is not defined``

Fixed import "date"