### PR TITLE
Added VSCode debug launch configuration with path mapping

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Remote Attach to Cheshire Cat plugin",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/",
+                    "remoteRoot": "/app/cat/plugins/${workspaceFolderBasename}/"
+                }
+            ],
+            "justMyCode": true
+        }
+    ]
+}


### PR DESCRIPTION
When the developer opens the plugin folder with VSCode, they can start debugging with the correct path mapping already set